### PR TITLE
download most packages from CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,15 +32,8 @@ Imports:
     ranger,
     xgboost
 Remotes:
-    mlr-org/mlr3,
-    mlr-org/mlr3pipelines,
     mlr-org/mlr3tuning,
-    mlr-org/mlr3learners,
-    mlr-org/mlr3extralearners,
     mlr-org/mlr3hyperband,
-    mlr-org/mlr3misc,
-    mlr-org/mlr3oml,
-    mlr-org/paradox,
     mlr-org/bbotk
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.1.2


### PR DESCRIPTION
When running the setup for openml/automlbenchmark, the current setup runs into download limitations from github due to downloading all mlr3-related packages.
This PR fixes this by downloading most mlr3 packages from CRAN